### PR TITLE
Close #44 Scanning support for Integers and Reals.

### DIFF
--- a/include/token.h
+++ b/include/token.h
@@ -49,7 +49,8 @@ typedef enum
   // Literals
   TOKEN_IDENTIFIER,
   TOKEN_STRING,
-  TOKEN_NUMBER,
+  TOKEN_INTEGER,
+  TOKEN_REAL,
 
   // Keywords.
   TOKEN_BEGIN,

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -107,11 +107,17 @@ static void binary();
  */
 static void literal();
 
-/** @brief Parse a number.
+/** @brief Parse a number as an integer.
  *
- * Parse a number constant from the source code.
+ * Parse an integer constant from the source code.
  */
-static void number();
+static void integer();
+
+/** @brief Parse a number as a real.
+ *
+ * Parse a real constant from the source code.
+ */
+static void real();
 
 /** @brief Parge a grouped expression.
  *
@@ -271,7 +277,8 @@ ParseRule rules[] = {
   { NULL,     binary,  PREC_COMPARISON }, // TOKEN_LESS_EQUAL
   { NULL,     NULL,    PREC_NONE },       // TOKEN_IDENTIFIER
   { NULL,     NULL,    PREC_NONE },       // TOKEN_STRING
-  { number,   NULL,    PREC_NONE },       // TOKEN_NUMBER
+  { integer,  NULL,    PREC_NONE },       // TOKEN_INTEGER
+  { real,     NULL,    PREC_NONE },       // TOKEN_REAL
   { NULL,     NULL,    PREC_NONE },       // TOKEN_BEGIN
   { NULL,     NULL,    PREC_NONE },       // TOKEN_BREAK
   { NULL,     NULL,    PREC_NONE },       // TOKEN_CASE
@@ -438,11 +445,21 @@ static void literal()
   }
 }
 
-/** @brief Parse a number.
+/** @brief Parse an integer number.
  *
- * Parse a number constant from the source code.
+ * Parse an integer constant from the source code.
  */
-static void number()
+static void integer()
+{
+  long value = strtol(parser.previous.lexeme, NULL, 10);
+  emit_constant(INTEGER_VAL(value));
+}
+
+/** @brief Parse an real number.
+ *
+ * Parse a real constant from the source code.
+ */
+static void real()
 {
   double value = strtod(parser.previous.lexeme, NULL);
   emit_constant(REAL_VAL(value));

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -276,18 +276,22 @@ static Token string()
  */
 static Token number()
 {
+  // Start out as an integer.
+  TokenType type = TOKEN_INTEGER;
+
   while(is_digit(peek(scanner)))
     advance(scanner);
 
   // Look for a fractional part.
   if(peek(scanner) == '.' && is_digit(peek_next(scanner)))
   {
+    type = TOKEN_REAL;
     advance(scanner);
     while(is_digit(peek(scanner)))
       advance(scanner);
   }
 
-  return make_token(TOKEN_NUMBER);
+  return make_token(type);
 }
 
 /** @brief Scan for an identifier or a keyword.

--- a/src/token.c
+++ b/src/token.c
@@ -79,8 +79,10 @@ const char *token_name(TokenType type)
       return "TOKEN_IDENTIFIER";
     case TOKEN_STRING:
       return "TOKEN_STRING";
-    case TOKEN_NUMBER:
-      return "TOKEN_NUMBER";
+    case TOKEN_INTEGER:
+      return "TOKEN_INTEGER";
+    case TOKEN_REAL:
+      return "TOKEN_REAL";
     case TOKEN_BEGIN:
       return "TOKEN_BEGIN";
     case TOKEN_BREAK:

--- a/src/value.c
+++ b/src/value.c
@@ -91,8 +91,6 @@ void write_value_array(ValueArray *array, Value value)
  */
 void print_value(Value value)
 {
-  printf("-> ");
-
   switch(value.type)
   {
     case CUBE_BOOL:

--- a/src/vm.c
+++ b/src/vm.c
@@ -373,6 +373,7 @@ static InterpretResult run()
       }
       case OP_RETURN:
       {
+        printf("-> ");
         print_value(pop());
         printf("\n");
         return INTERPRET_OK;


### PR DESCRIPTION
Separated TOKEN_NUMBER into TOKEN_INTEGER and TOKEN_REAL. The scanner now creates a TOKEN_INTEGER during number processing by default. If a '.' is found then a TOKEN_REAL will be created instead.

In the compiler I added the new token types to the `rules` array and split the number parsing function into separate `integer()` and `real()` functions.

Also fixed a small issue with Value printing. The prefix used in the REPL (->) for output was being printed with the value, so when dumping code the OP_CONSTANTs would look like '-> 3'. I moved the output prefix to the virtual machine return operation so it will only be printed when displaying the result of an expression.