### PR TITLE
Close #40 Cleaned up header includes across the project.

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -5,13 +5,9 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <assert.h>
 
 #include "error.h"
 

--- a/src/cube.c
+++ b/src/cube.c
@@ -9,6 +9,8 @@
  * @author David J. Lains (dlains)
  * @bug No known bugs.
  */
+#include <stdio.h>
+#include <stdlib.h>
 #include "common.h"
 #include "chunk.h"
 #include "debug.h"

--- a/src/keywords.c
+++ b/src/keywords.c
@@ -5,7 +5,8 @@
  * @author David J. Lains (dlains)
  * @bug No known bugs.
  */
-
+#include <stdlib.h>
+#include <string.h>
 #include "keywords.h"
 #include "token.h"
 

--- a/src/options.c
+++ b/src/options.c
@@ -5,6 +5,9 @@
  * @author David J. Lains (dlains)
  * @bug No known bugs.
  */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <getopt.h>
 #include "common.h"
 #include "memory.h"

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -5,7 +5,7 @@
  * @author David J. Lains (dlains)
  * @bug No known bugs
  */
-
+#include <string.h>
 #include "common.h"
 #include "keywords.h"
 #include "scanner.h"

--- a/src/source.c
+++ b/src/source.c
@@ -6,6 +6,7 @@
  * @bug No known bugs.
  */
 #include <stdio.h>
+#include <string.h>
 #include "common.h"
 #include "memory.h"
 #include "source.h"


### PR DESCRIPTION
Removed many of the standard library headers from common.h and made sure they were included in the source files that actually need them. This should reduce compile time a bit and keep extraneous info out of the source files.