### PR TITLE
Close #55 Free the lexeme when necessary.

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -36,4 +36,9 @@ void die(const char *message, const char *file, int line);
  */
 void parse_error(Token *token, const char *message);
 
+/**
+ * Simplify calling die.
+ */
+#define DIE(message) die((message), __FILE__, __LINE__)
+
 #endif // ERROR_H

--- a/include/token.h
+++ b/include/token.h
@@ -100,6 +100,14 @@ typedef struct
  */
 Token token_create(TokenType type, String lexeme, int line, int col);
 
+/** @brief Free the tokens resources.
+ *
+ * Check to see if lexeme is not null. If not, free the memory.
+ *
+ * @param token The token to free.
+ */
+void token_free(Token token);
+
 /** @brief Translate a token enum id to a user friendly token name.
  *
  * This function returns the token name for a given token id. If the token

--- a/src/common.c
+++ b/src/common.c
@@ -20,6 +20,9 @@
  */
 String string_init(const char *s)
 {
+  if(!s)
+    DIE("Invalid string pointer.");
+
   String result = ALLOC(char, strlen(s) + 1);
   strcpy(result, s);
 
@@ -38,6 +41,12 @@ String string_init(const char *s)
  */
 String string_copy(const char *s, int length)
 {
+  if(!s)
+    DIE("Invalid string pointer.");
+
+  if(length <= 0)
+    DIE("String length must be larger than zero.");
+
   String result = ALLOC(char, length + 1);
   strncpy(result, s, length);
   result[length] = '\0';

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -331,6 +331,7 @@ static ParseRule *get_rule(TokenType type)
  */
 static void advance(void)
 {
+  token_free(parser.previous);
   parser.previous = parser.current;
 
   for(;;)

--- a/src/source.c
+++ b/src/source.c
@@ -16,7 +16,7 @@
  * Defines the source code to be parsed and interpreted.
  */
 struct source {
-  char *buffer;            /**< The rolling buffer to hold the source code. */
+  String buffer;           /**< The rolling buffer to hold the source code. */
   const char *start;       /**< The start of the current token being scanned. */
   const char *current;     /**< The current location in the buffer. */
   const char *file;        /**< The full path to the file associated with this buffer. NULL for non file buffers. */
@@ -42,8 +42,7 @@ static char *source_read_file(const char *file_path);
 Source source_create(const char *source)
 {
   Source s   = NEW(s);
-  s->buffer  = ALLOC(char, strlen(source));
-  memcpy(s->buffer, source, strlen(source));
+  s->buffer  = string_init(source);
   s->start   = s->buffer;
   s->current = s->buffer;
   s->file    = NULL;

--- a/src/token.c
+++ b/src/token.c
@@ -9,8 +9,8 @@
  * @author David J. Lains
  * @bug No known bugs
  */
-
 #include <stdio.h>
+#include "memory.h"
 #include "token.h"
 
 /** @brief Create a new token.
@@ -33,6 +33,20 @@ Token token_create(TokenType type, String lexeme, int line, int col)
   token.col    = col;
 
   return token;
+}
+
+/** @brief Free the tokens resources.
+ *
+ * Check to see if lexeme is not null. If not, free the memory.
+ *
+ * @param token The token to free.
+ */
+void token_free(Token token)
+{
+  if(token.lexeme != NULL)
+  {
+    FREE(char, token.lexeme);
+  }
 }
 
 /** @brief Translate a token enum id to a user friendly token name.


### PR DESCRIPTION
Also fixed an issued in the Source module when running as a REPL. The code that copied the line of source code was not terminating the string correctly, so sometimes the final token on the line was extended or caused an error. Converted the Source buffer to String and the line copy to string_init().