### PR TITLE
Close #60 Converted CUBE_NIL to an object.

### DIFF
--- a/include/chunk.h
+++ b/include/chunk.h
@@ -19,7 +19,6 @@
  */
 typedef enum {
   OP_CONSTANT,
-  OP_NIL,
   OP_EQUAL,
   OP_GREATER,
   OP_LESS,

--- a/include/object.h
+++ b/include/object.h
@@ -15,6 +15,7 @@
 
 typedef struct object Object;
 typedef struct object_boolean ObjectBoolean;
+typedef struct object_nil ObjectNil;
 typedef struct object_string ObjectString;
 
 /** Retrieve the ObjectType from the given object. */
@@ -23,11 +24,17 @@ typedef struct object_string ObjectString;
 /** Check if the given object is a Boolean object. */
 #define IS_BOOLEAN(value)     is_object_type(value, OBJ_BOOLEAN)
 
+/** Check if the given object is a Nil object. */
+#define IS_NIL(value)         is_object_type(value, OBJ_NIL)
+
 /** Check if the given Value is an object with OBJ_STRING type. */
 #define IS_STRING(value)      is_object_type(value, OBJ_STRING)
 
 /** Get the Object as a ObjectBoolean pointer. */
 #define AS_BOOLEAN(value)     ((ObjectBoolean*)AS_OBJECT(value))
+
+/** Get the Object as a ObjectNil pointer. */
+#define AS_NIL(value)         ((ObjectNil*)AS_OBJECT(value))
 
 /** Get the Value as a ObjectString pointer. */
 #define AS_STRING(value)      ((ObjectString*)AS_OBJECT(value))
@@ -38,6 +45,7 @@ typedef struct object_string ObjectString;
 /** Enumerate the different kinds of Objects. */
 typedef enum {
   OBJ_BOOLEAN,     /**< The Boolean ObjectType. */
+  OBJ_NIL,         /**< The Nil ObjectType. */
   OBJ_STRING,      /**< The String ObjectType. */
 } ObjectType;
 
@@ -51,6 +59,11 @@ struct object {
 struct object_boolean {
   Object object;            /**< The actual object pointer. */
   bool value;               /**< The boolean value. */
+};
+
+struct object_nil {
+  Object object;            /**< The actual object pointer. */
+  int value;                /**< Nil is represented as int = 0. */
 };
 
 /** Define the object_string structure. */
@@ -76,6 +89,14 @@ void free_object(Object *object);
  * @return The newly created ObjectBoolean.
  */
 ObjectBoolean *create_boolean(bool value);
+
+/** @brief Create a nil object.
+ *
+ * Create an ObjectNil constant.
+ *
+ * @return The newly created ObjectNil.
+ */
+ObjectNil *create_nil(void);
 
 /** @brief Take a string and turn it into a ObjectString.
  *

--- a/include/value.h
+++ b/include/value.h
@@ -15,6 +15,7 @@
 
 typedef struct object Object;
 typedef struct object_boolean ObjectBoolean;
+typedef struct object_nil ObjectNil;
 typedef struct object_string ObjectString;
 
 /** @enum ValueType
@@ -22,7 +23,6 @@ typedef struct object_string ObjectString;
  * Keep track of the actual type for a Value.
  */
 typedef enum {
-  CUBE_NIL,      /**< Nil, no value */
   CUBE_INTEGER,  /**< Signed integers */
   CUBE_REAL,     /**< Signed floating point values */
   CUBE_OBJECT,   /**< Pointer to a larger type */
@@ -44,9 +44,6 @@ typedef struct {
 //
 // Create Value helper macros.
 //
-
-/** Create a Value with type CUBE_NIL */
-#define NIL_VAL              ((Value){ CUBE_NIL,     { .real = 0 } })
 
 /** Create a Value with type CUBE_INTEGER */
 #define INTEGER_VAL(value)   ((Value){ CUBE_INTEGER, { .integer = value } })
@@ -76,9 +73,6 @@ typedef struct {
 
 /** Check if Value is a CUBE_OBJECT. */
 #define IS_OBJECT(value)     ((value).type == CUBE_OBJECT)
-
-/** Check if Value is a CUBE_NIL. */
-#define IS_NIL(value)        ((value).type == CUBE_NIL)
 
 /** Check if Value is a CUBE_INTEGER. */
 #define IS_INTEGER(value)    ((value).type == CUBE_INTEGER)

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -444,7 +444,7 @@ static void literal()
       emit_constant(OBJECT_VAL(create_boolean(false)));
       break;
     case TOKEN_NIL:
-      emit_byte(OP_NIL);
+      emit_constant(OBJECT_VAL(create_nil()));
       break;
     case TOKEN_TRUE:
       emit_constant(OBJECT_VAL(create_boolean(true)));

--- a/src/debug.c
+++ b/src/debug.c
@@ -62,12 +62,6 @@ int disassemble_instruction(Chunk *chunk, int offset)
   {
     case OP_CONSTANT:
       return constant_instruction("OP_CONSTANT", chunk, offset);
-    case OP_FALSE:
-      return simple_instruction("OP_FALSE", offset);
-    case OP_NIL:
-      return simple_instruction("OP_NIL", offset);
-    case OP_TRUE:
-      return simple_instruction("OP_TRUE", offset);
     case OP_EQUAL:
       return simple_instruction("OP_EQUAL", offset);
     case OP_GREATER:

--- a/src/object.c
+++ b/src/object.c
@@ -71,6 +71,11 @@ void free_object(Object *object)
       FREE(ObjectBoolean, object);
       break;
     }
+    case OBJ_NIL:
+    {
+      FREE(ObjectNil, object);
+      break;
+    }
     case OBJ_STRING:
     {
       ObjectString *string = (ObjectString*)object;
@@ -94,6 +99,20 @@ ObjectBoolean *create_boolean(bool value)
   boolean->value         = value;
 
   return boolean;
+}
+
+/** @brief Create a nil object.
+ *
+ * Create an ObjectNil constant.
+ *
+ * @return The newly created ObjectNil.
+ */
+ObjectNil *create_nil(void)
+{
+  ObjectNil *nil = ALLOCATE_OBJECT(ObjectNil, OBJ_NIL);
+  nil->value     = 0;
+
+  return nil;
 }
 
 /** @brief Allocate an object of ObjectType string.

--- a/src/value.c
+++ b/src/value.c
@@ -30,8 +30,6 @@ bool values_equal(Value a, Value b)
 
   switch(a.type)
   {
-    case CUBE_NIL:
-      return true;
     case CUBE_INTEGER:
       return AS_INTEGER(a) == AS_INTEGER(b);
     case CUBE_REAL:
@@ -48,6 +46,11 @@ bool values_equal(Value a, Value b)
           ObjectBoolean* aBool = AS_BOOLEAN(a);
           ObjectBoolean* bBool = AS_BOOLEAN(b);
           return aBool->value == bBool->value;
+        }
+        case OBJ_NIL:
+        {
+          // Both object have already been establised to be nil, and nil always equals nil.
+          return true;
         }
         case OBJ_STRING:
         {
@@ -80,6 +83,9 @@ void print_object(Value value)
       printf("%s", b->value ? "true" : "false");
       break;
     }
+    case OBJ_NIL:
+      printf("nil");
+      break;
     case OBJ_STRING:
       printf("\"%s\"", AS_CSTRING(value));
       break;
@@ -99,9 +105,6 @@ void print_value(Value value)
 {
   switch(value.type)
   {
-    case CUBE_NIL:
-      printf("nil");
-      break;
     case CUBE_INTEGER:
       printf("%ld", AS_INTEGER(value));
       break;

--- a/src/vm.c
+++ b/src/vm.c
@@ -314,11 +314,6 @@ static InterpretResult run()
         do_less();
         break;
       }
-      case OP_NIL:
-      {
-        push(NIL_VAL);
-        break;
-      }
       case OP_ADD:
       {
         if(IS_STRING(peek(0)) && IS_STRING(peek(1)))
@@ -763,7 +758,6 @@ static void do_negate()
     case CUBE_REAL:
       push(REAL_VAL(-AS_REAL(v)));
       break;
-    case CUBE_NIL:
     default:
       break;
   }


### PR DESCRIPTION
Similarly to the ObjectBoolean conversion, there is a new ObjectNil created every time it is encountered in the source code. This will be fixed when global variables are added.