### PR TITLE
Close #71 Fixed issue with binary operators.

### DIFF
--- a/include/vm.h
+++ b/include/vm.h
@@ -27,7 +27,7 @@ typedef struct
   Byte *ip;                   /**< The instruction pointer. This is the next operation to perform. */
   Options options;            /**< The command line options. */
   Object *stack[STACK_MAX];   /**< The value stack to hold intermediate results during processing. */
-  Object *stack_top;          /**< Pointer to the top of the value stack. */
+  Object **stack_top;         /**< Pointer to the top of the object stack. */
   Object *objects;            /**< Linked list of objects. */
 } VM;
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -201,7 +201,7 @@ InterpretResult interpret()
  */
 void push(Object *object)
 {
-  vm.stack_top = object;
+  *vm.stack_top = object;
   vm.stack_top++;
 }
 
@@ -214,7 +214,7 @@ void push(Object *object)
 Object *pop()
 {
   vm.stack_top--;
-  return vm.stack_top;
+  return *vm.stack_top;
 }
 
 /** @brief Peek at an object in the stack.
@@ -227,7 +227,7 @@ Object *pop()
  */
 static Object *peek(int distance)
 {
-  return &vm.stack_top[-1 - distance];
+  return vm.stack_top[-1 - distance];
 }
 
 /** @brief Release the linked list of objects from the VM.
@@ -399,7 +399,7 @@ static InterpretResult run()
  */
 static void reset_stack()
 {
-  vm.stack_top = vm.stack[0];
+  vm.stack_top = vm.stack;
 }
 
 /** @brief Display a runtime error message to stderr.


### PR DESCRIPTION
It was a problem with how the VM stack was defined. The pointer to the top of the stack needed to be a pointer to a pointer, and pushing and popping values from the stack needed to be fixed.