### PR TITLE
Close #76 Fixed issue with interned strings.

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -188,7 +188,7 @@ static void end_compiler();
  *
  * Add the byte codes to access an object to the Chunk array.
  *
- * @param object The object constant to reference. 
+ * @param object The object constant to reference.
  */
 static void emit_constant(Object *object);
 
@@ -481,7 +481,7 @@ static void real()
  */
 static void string()
 {
-  emit_constant(AS_OBJECT(copy_string(parser.previous.lexeme + 1, strlen(parser.previous.lexeme) - 2)));
+  emit_constant(AS_OBJECT(copy_string(parser.previous.lexeme, strlen(parser.previous.lexeme))));
 }
 
 /** @brief Parse a grouped expression.
@@ -592,7 +592,7 @@ static void end_compiler()
  *
  * Add the byte codes to access an object to the Chunk array.
  *
- * @param object The object constant to reference. 
+ * @param object The object constant to reference.
  */
 static void emit_constant(Object *object)
 {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -201,11 +201,15 @@ static Token make_token(TokenType type)
   switch(type)
   {
     case TOKEN_IDENTIFIER:
-    case TOKEN_STRING:
     case TOKEN_INTEGER:
     case TOKEN_REAL:
     {
       String lexeme = string_copy(start_position(scanner), token_length(scanner));
+      return token_create(type, lexeme, line_number(scanner), col_number(scanner));
+    }
+    case TOKEN_STRING:
+    {
+      String lexeme = string_copy(start_position(scanner) + 1, token_length(scanner) - 2);
       return token_create(type, lexeme, line_number(scanner), col_number(scanner));
     }
     default:


### PR DESCRIPTION
The problem was how the scanner was handling string lexemes. It would copy the string along with the enclosing quotes. So the C string would look like "hello" instead of simply hello. Fixed the scanner to remove the quotes so that internally Cube strings are just the characters inside the quotes.