### PR TITLE
Close #83 Fixed issue with local variable not being found.

### DIFF
--- a/include/token.h
+++ b/include/token.h
@@ -102,6 +102,15 @@ typedef struct
  */
 Token token_create(TokenType type, String lexeme, int line, int col);
 
+/** @brief Duplicate a token.
+ *
+ * Deep copy the source token to a new token.
+ *
+ * @param source The source token to copy.
+ * @return The newly created duplicate token.
+ */
+Token token_duplicate(Token source);
+
 /** @brief Free the tokens resources.
  *
  * Check to see if lexeme is not null. If not, free the memory.

--- a/src/memory.c
+++ b/src/memory.c
@@ -33,6 +33,7 @@ void *reallocate(void *previous, size_t old_size, size_t new_size, const char *f
   if(new_size == 0)
   {
     free(previous);
+    previous = NULL;
     return NULL;
   }
 

--- a/src/token.c
+++ b/src/token.c
@@ -11,6 +11,8 @@
  */
 #include "config.h"
 #include <stdio.h>
+#include <string.h>
+#include "common.h"
 #include "memory.h"
 #include "token.h"
 
@@ -32,6 +34,27 @@ Token token_create(TokenType type, String lexeme, int line, int col)
   token.lexeme = lexeme;
   token.line   = line;
   token.col    = col;
+
+  return token;
+}
+
+/** @brief Duplicate a token.
+ *
+ * Deep copy the source token to a new token.
+ *
+ * @param source The source token to copy.
+ * @return The newly created duplicate token.
+ */
+Token token_duplicate(Token source)
+{
+  Token token;
+
+  token.type   = source.type;
+  token.line   = source.line;
+  token.col    = source.col;
+
+  if(source.lexeme != NULL)
+    token.lexeme = string_copy(source.lexeme, strlen(source.lexeme));
 
   return token;
 }


### PR DESCRIPTION
The token being stored in the Compiler locals array was a pointer to the parser token. When the parser moved on to the next token the token in the locals array was also updated. When the local variable lookup would execute it would see two different identifier names. I made a token_duplicate function in the Tokens module to make sure the Token stored in the locals array was independent.